### PR TITLE
Upgrading and using the latest 1.26.4 go syntax

### DIFF
--- a/dockerfolder/Dockerfile
+++ b/dockerfolder/Dockerfile
@@ -1,7 +1,7 @@
 # Build from the root directory using: docker build -f dockerfolder/Dockerfile -t gopdfsuit .
 
 # --- Build stage ---
-FROM golang:1.24.11-bookworm AS builder
+FROM golang:1.26.4-bookworm AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && \
 	rm -rf /var/lib/apt/lists/*

--- a/dockerfolder/Dockerfile_cloudrun
+++ b/dockerfolder/Dockerfile_cloudrun
@@ -1,5 +1,5 @@
 # --- Stage 1: Build the Go application ---
-FROM golang:1.24.11-bookworm AS builder
+FROM golang:1.26.4-bookworm AS builder
 RUN apt-get update && apt-get install -y ca-certificates
 
 WORKDIR /app

--- a/frontend/go.mod
+++ b/frontend/go.mod
@@ -1,4 +1,4 @@
 // This module file has been added to skip the download for go get
 module github.com/chinmay-sawant/gopdfsuit/v6/frontend
 
-go 1.24.0
+go 1.26.4

--- a/guides/GO_1_26_4_FEATURE_GUIDE.md
+++ b/guides/GO_1_26_4_FEATURE_GUIDE.md
@@ -1,0 +1,408 @@
+# Go 1.26.4 Feature Guide for gopdfsuit
+
+**Date:** 2026-06-17  
+**Toolchain:** Go 1.26.4 (`go.mod` in the main module, `sampledata/`, `certs/`, and most submodules)  
+**Audience:** Contributors optimizing PDF generation throughput, memory, and operational safety
+
+This guide maps Go 1.26.x language, runtime, compiler, and standard-library changes to concrete areas of this repository. Go 1.26.4 is a patch release on the 1.26 line; the features below come from Go 1.26.0 and remain available in 1.26.4.
+
+---
+
+## Executive summary
+
+| Category | Impact for gopdfsuit | Action |
+|----------|----------------------|--------|
+| Green Tea GC (default) | High — PDF work is allocation-heavy | Already active when built with Go 1.26.4; validate with existing k6 + pprof harness |
+| Stack-backed slice allocation | Medium–High — many hot `make`/`append` paths | Already active; watch for rare miscompiles via bisect |
+| Faster `io.ReadAll` | Medium — upload/redact handlers | Already active on stdlib call sites |
+| Faster `image/jpeg` | Medium — base64 JPEG rows in templates | Already active; re-run image-heavy integration tests |
+| Faster cgo | Low–Medium — indirect via chromedp stack | Automatic if cgo is linked |
+| `go fix` modernizers | Medium — codebase hygiene | Run once, review diff |
+| `B.Loop` benchmarks | Medium — more trustworthy bench numbers | Migrate remaining `b.N` loops |
+| `runtime/secret` (experimental) | Medium — signing key handling | Evaluate for `internal/pdf/signature` |
+| `goroutineleak` profile (experimental) | Medium — worker pools under load | Enable in CI/staging load tests |
+| `new(expr)` | Low — readability in models/tests | Optional cleanup |
+| `simd/archsimd` (experimental) | Unknown — SIMD for scan/compress paths | Research only; not production-ready |
+| `crypto/hpke`, ML-KEM TLS | Low today | Relevant if adding HPKE or hardening outbound TLS |
+
+**Bottom line:** The largest wins require no code changes — you are already on Go 1.26.4 and this workload (pooled buffers, caches, short-lived slices, JSON/PDF bytes) is exactly what Green Tea and the improved `io.ReadAll` target. Focus next on validation (`make bench-k6`), benchmark modernization, and selective experiments (`goroutineleak`, `runtime/secret`).
+
+---
+
+## 1. Already benefiting (no code changes required)
+
+Build and run with Go 1.26.4 and these improvements apply automatically.
+
+### 1.1 Green Tea garbage collector (default since Go 1.26)
+
+**What it does:** Re-architects parallel GC marking/sc scanning for better cache locality on small objects. Typical programs see **10–40% lower GC CPU**; on newer amd64 (Intel Ice Lake+, AMD Zen 4+) an additional ~10% from vectorized small-object scanning.
+
+**Why it matters here:** gopdfsuit is GC-heavy by design:
+
+- `sync.Pool` for PDF buffers, scratch buffers, JSON decode bodies, SHA-256 hashers, zlib writers, RGB conversion, and pooled `PDFTemplate` instances (`internal/pdf/generator.go`, `internal/handlers/json_decode.go`, `internal/pdf/signature/signature.go`, `internal/pdf/image.go`, `internal/pdf/font/compression.go`).
+- Per-request short-lived slices during PDF assembly, structure trees, and table rendering.
+- Cross-request caches (`subsetCache`, `imgCache`, `propsCache`, `pdfSignerCache`) that retain heap objects between requests.
+
+These patterns create many small, short-lived allocations — the profile Green Tea improves most.
+
+**How to validate:**
+
+```bash
+make bench-k6
+# Compare pprof GC time vs pre-1.26 baselines in guides/cursor/baselines/gin_pprof_runs/
+```
+
+Look for reduced time in `runtime.gcBgMarkWorker`, `mallocgc`, and `scanobject` in CPU profiles. Heap profiles may show similar in-use bytes but lower allocation churn (`alloc_space`).
+
+**Opt-out (debug only):** `GOEXPERIMENT=nogreenteagc` at build time. Only use to A/B test; the setting is expected to be removed in Go 1.27.
+
+**Note:** `frontend/go.mod` still declares `go 1.24.0`. Align it when that module is built with 1.26.4 so tooling and CI stay consistent.
+
+---
+
+### 1.2 Stack-backed slice backing stores (compiler)
+
+**What it does:** The compiler can place slice backing arrays on the stack in more cases, avoiding heap allocations for slices that do not escape.
+
+**Relevant code paths:**
+
+- `internal/pdf/generator.go` — extensive `append`/`make` for AcroForm content, structure output, scratch buffers.
+- `internal/pdf/draw.go`, `internal/pdf/font/metrics.go` — formatting and layout temporaries.
+- `typstsyntax/renderer.go` — grid layout slices and point arrays for math rendering.
+
+**Expected effect:** Small per-operation savings that compound under 1000+ req/s load. Hard to see in macro benchmarks but should nudge `alloc_space` down in pprof.
+
+**If something breaks:** Use bisect with `-compile=variablemake` or disable via `-gcflags=all=-d=variablemakehash=n` and file a Go issue.
+
+---
+
+### 1.3 Faster `io.ReadAll` (stdlib)
+
+**What it does:** ~2× faster on large inputs, ~half the intermediate allocations, minimally sized result slice.
+
+**Call sites in this repo:**
+
+| Area | Files |
+|------|-------|
+| HTTP handlers | `internal/handlers/handlers.go`, `internal/handlers/redact.go` |
+| Integration tests | `test/integration_*.go` |
+
+Redact endpoints read full uploaded PDFs via `io.ReadAll`. Under load, this reduces allocator pressure before PDF parsing even starts.
+
+**Note:** JSON decode for `/generate/template-pdf` uses pooled `io.ReadFull` in `internal/handlers/json_decode.go` — that path is already optimized and bypasses `ReadAll` for known `Content-Length`. The stdlib win applies to redact/multipart and test helpers.
+
+---
+
+### 1.4 Faster `image/jpeg` encoder/decoder (stdlib)
+
+**What it does:** New JPEG implementation — faster and more accurate. Bit-exact output with the old encoder is not guaranteed.
+
+**Relevant code:** `internal/pdf/image.go` registers `image/jpeg` and decodes base64 JPEG rows from templates.
+
+**Action:** Re-run image-related integration tests and any golden PDF comparisons that embed JPEG assets. Expect decode CPU savings on templates with many image rows (retail Zerodha-style payloads).
+
+---
+
+### 1.5 ~30% lower cgo call overhead (runtime)
+
+**What it does:** Reduces baseline cost of Go ↔ C transitions.
+
+**Relevance:** gopdfsuit does not use `import "C"` directly, but dependencies such as **chromedp** (screenshots / headless flows in `screenshots/`) may link cgo. Any chromedp-heavy path benefits automatically.
+
+---
+
+### 1.6 Crypto speed and safety defaults (stdlib)
+
+Relevant to signing and encryption in this repo:
+
+| Package / change | gopdfsuit usage | Benefit |
+|------------------|-----------------|---------|
+| `crypto/ecdsa`, `crypto/rsa` signing | `internal/pdf/signature/signature.go` — `rsa.SignPKCS1v15`, `ecdsa.SignASN1` | Cleaner RNG handling; `rand` param ignored (always secure source) |
+| `crypto/mlkem` ~18% faster | Not used directly | Future PQ work |
+| `crypto/tls` ML-KEM hybrids default | Only if you terminate TLS in-process | Stronger default handshakes |
+| `testing/cryptotest.SetGlobalRandom` | `internal/pdf/signature/signature_test.go` | Deterministic signature tests without passing custom `rand` |
+
+Signing is on the ECDSA Zerodha benchmark path (~80% of weighted k6 traffic). Faster, safer crypto stacks marginally reduce tail latency on signed PDFs.
+
+---
+
+## 2. Recommended adoptions (low risk, clear payoff)
+
+### 2.1 Run `go fix` modernizers
+
+Go 1.26 rewrote `go fix` as a modernizer suite (same analysis framework as `go vet`). It applies dozens of safe idiomatic updates.
+
+```bash
+# Preview
+go fix -fix=all ./... 
+
+# Or run specific analyzers; review diff before commit
+go fix ./internal/... ./pkg/... ./cmd/...
+```
+
+**Suggested workflow:**
+
+1. Run on a clean branch.
+2. Review the diff — modernizers should not change behavior.
+3. Run `make test` (or your usual `go test ./...`) and a quick `make bench-k6` spot check.
+
+Use `//go:fix inline` on any deprecated internal helpers you want callers migrated away from automatically.
+
+---
+
+### 2.2 Migrate benchmarks from `b.N` to `b.Loop`
+
+Go 1.26 fixed `B.Loop` so loop bodies can inline correctly (older `B.Loop` prevented inlining and skewed results).
+
+**Files still using `b.N`:**
+
+- `internal/pdf/benchmark_test.go`
+- `internal/pdf/benchmark_macro_test.go`
+- `internal/pdf/benchmark_compare_test.go`
+- `sampledata/benchmarks/gopdfkit_compare/compare_benchmark_test.go`
+- `test/benchmark_handlers_test.go` (partial — also uses `pb.Next()`)
+
+**Before:**
+
+```go
+for i := 0; i < b.N; i++ {
+    generatePDF(template)
+}
+```
+
+**After:**
+
+```go
+for b.Loop() {
+    generatePDF(template)
+}
+```
+
+**Why:** More accurate microbenchmarks when evaluating optimizations documented in `guides/optimizations/`. Misleading bench numbers have already led to reverted changes (e.g. generic structure writer, aggressive pool caps in the optimization checklist).
+
+---
+
+### 2.3 Use pprof flame graphs by default
+
+Go 1.26’s `go tool pprof -http` now opens the **flame graph** view first.
+
+Your harness already captures profiles:
+
+```bash
+test/generate_template-pdf/run_gin_pprof_load.sh
+```
+
+When analyzing `guides/cursor/baselines/gin_pprof_runs/pprof_summary_*.txt`, prefer the web UI for hot-path visualization:
+
+```bash
+go tool pprof -http=:8081 ./bin/gopdfsuit guides/cursor/baselines/gin_pprof_runs/cpu_*.prof
+```
+
+Graph view remains under **View → Graph** if you need the old layout.
+
+---
+
+### 2.4 `errors.AsType` for typed error handling
+
+Go 1.26 adds `errors.AsType[T](err) (T, bool)` — type-safe and faster than `errors.As`.
+
+**Today:** The codebase rarely uses `errors.As`. As error wrapping grows (merge, redact, signature, encryption), prefer:
+
+```go
+var pathErr *os.PathError
+if errors.As(err, &pathErr) { ... }
+
+// Go 1.26+
+if pathErr, ok := errors.AsType[*os.PathError](err); ok { ... }
+```
+
+Most useful in handler error mapping and library boundaries (`pkg/gopdflib`).
+
+---
+
+### 2.5 `fmt.Errorf` allocation reduction
+
+Static format strings like `fmt.Errorf("missing PDF header")` now allocate similarly to `errors.New`. Many validation errors in benchmarks and handlers use static strings — no migration required; they already benefit.
+
+---
+
+## 3. Language features (readability, limited performance impact)
+
+### 3.1 `new(expression)` — initialize pointer fields in one step
+
+Go 1.26 allows `new(expr)` instead of helper variables.
+
+**Relevant models** (`internal/models/models.go`) use optional pointer fields:
+
+- `EmbedFonts *bool`
+- `Checkbox *bool`, `Wrap *bool`, `MathEnabled *bool`
+- `Width *float64`, `Height *float64`
+
+**Example — building a test fixture or default config:**
+
+```go
+// Before
+v := true
+cfg := models.Config{EmbedFonts: &v}
+
+// Go 1.26
+cfg := models.Config{EmbedFonts: new(true)}
+```
+
+```go
+// Before
+w, h := 200.0, 50.0
+sig := models.SignatureConfig{Width: &w, Height: &h}
+
+// Go 1.26
+sig := models.SignatureConfig{
+    Width:  new(200.0),
+    Height: new(50.0),
+}
+```
+
+**Performance:** Negligible. **Value:** Less boilerplate in tests and sampledata (`sampledata/gopdflib/zerodha/main.go`, benchmarks).
+
+---
+
+### 3.2 Self-referential generic constraints
+
+Generic types can now refer to themselves in constraints, e.g. `type Adder[A Adder[A]] interface { Add(A) A }`.
+
+**Relevance to gopdfsuit:** Limited today — the codebase is not generic-heavy. A prior generic structure-writer experiment in `internal/pdf/generator.go` **regressed** throughput (shape-based dispatch, not monomorphization) and was reverted (`guides/optimizations/20260614_remaining_optimizations_checklist.md`).
+
+**Guidance:** Do **not** reintroduce generics for PDF hot paths based on this feature alone. Self-referential constraints are useful if you later model tree-shaped layout IR or pluggable element types — not for micro-optimizations.
+
+---
+
+## 4. Experimental features worth evaluating
+
+### 4.1 Goroutine leak profile
+
+**Enable at build:**
+
+```bash
+GOEXPERIMENT=goroutineleakprofile go build -o bin/gopdfsuit ./cmd/gopdfsuit
+```
+
+**Endpoint:** `/debug/pprof/goroutineleak` (when pprof routes are enabled and `ENABLE_PROFILING=1` / localhost middleware allows access).
+
+**Why it matters here:**
+
+- Concurrency limiting via semaphores: `cmd/gopdfsuit/main.go`, `internal/pdf/signature/signature.go` (`signWorkerSlots`), `internal/pdf/generator.go` (`pageCompressSlots`).
+- Worker pools in benchmarks and `golang.org/x/sync/errgroup` in `internal/pdf/generator.go`.
+- Early-return paths in parallel work (classic leak pattern from Go release notes).
+
+**Use case:** Run under k6 load, then capture `goroutineleak` profile after sustained traffic. Helps catch stuck workers that hold memory and slots, depressing throughput toward the ~1500 req/s target.
+
+Expected to become default in Go 1.27 — validating now reduces surprise later.
+
+---
+
+### 4.2 `runtime/secret` — secure erasure of key material
+
+**Enable at build:**
+
+```bash
+GOEXPERIMENT=runtimesecret go build ./...
+```
+
+**Relevant code:** `internal/pdf/signature/signature.go` parses PEM private keys into `crypto.PrivateKey` and signs PDFs; `internal/models/models.go` carries `PrivateKeyPEM` in JSON config.
+
+**Potential use:** Wrap signing operations so key bytes and temporaries are cleared from stack/registers/heap after use. Important for forward secrecy and compliance narratives — not a throughput optimization.
+
+**Status:** Experimental, amd64/arm64 Linux only. Evaluate in staging before production signing paths.
+
+---
+
+### 4.3 `simd/archsimd` — architecture-specific SIMD
+
+**Enable:** `GOEXPERIMENT=simd`  
+**Status:** Experimental, amd64 only, API unstable.
+
+**Hypothetical fits (research only):**
+
+- RGB conversion / image scan loops in `internal/pdf/image.go`
+- Zlib compression in `internal/pdf/font/compression.go`
+- FNV-1a hashing in `internal/pdf/image.go`
+
+**Guidance:** Do not ship in production PDF paths until a portable API exists. Benchmark in isolation first; PDF generation is rarely SIMD-bound compared to JSON decode, font subsetting, and structure-tree I/O.
+
+---
+
+## 5. Standard-library additions with future relevance
+
+| Feature | When to adopt |
+|---------|----------------|
+| `crypto/hpke` | If adding hybrid encryption for document or key exchange APIs |
+| `bytes.Buffer.Peek` | PDF stream parsers that currently read-then-unread bytes |
+| `log/slog.NewMultiHandler` | If structured logging is added alongside Gin |
+| `net/http/httputil.ReverseProxy.Rewrite` | If adding a reverse proxy in front of the API |
+| `reflect.Type.Fields` iterators | Reflection-heavy tooling, not hot PDF paths |
+| `testing.{T,B,F}.ArtifactDir` | Store generated PDF artifacts from failing tests with `go test -artifacts` |
+| `runtime/metrics` scheduler counters | Custom dashboards for goroutine/scheduling pressure under k6 |
+
+---
+
+## 6. Features with little or no benefit here
+
+| Feature | Reason |
+|---------|--------|
+| `go mod init` default version change | Existing modules already pin `go 1.26.4` |
+| Removal of `cmd/doc` | Use `go doc` |
+| WebAssembly heap changes | Not a WASM deployment |
+| Darwin / PowerPC port notes | Deployment targets differ |
+| `net/url` strict colon parsing | Unless user-supplied URLs are parsed in new code |
+
+---
+
+## 7. Suggested validation plan
+
+Align with existing benchmark culture in `guides/INTEGRATION_AND_BENCHMARK_TESTS.md` and `guides/optimizations/`.
+
+### Phase A — Confirm runtime wins (no code diff)
+
+1. Build with Go 1.26.4: `go build -o bin/gopdfsuit ./cmd/gopdfsuit`
+2. Run `make bench-k6` twice; compare to baselines in `guides/cursor/baselines/gin_pprof_runs/`
+3. Check CPU profile for GC/mark shrinkage; check `alloc_space` on heap profile
+
+### Phase B — Tooling and benchmarks
+
+1. `go fix ./...` — review and commit idiomatic updates
+2. Convert `b.N` → `b.Loop` in `internal/pdf/benchmark_*.go`
+3. Re-run `go test -bench=. ./internal/pdf/...` and note delta (expect small, directionally trustworthy)
+
+### Phase C — Experiments (optional branch)
+
+1. `GOEXPERIMENT=goroutineleakprofile` — load test + leak profile
+2. `GOEXPERIMENT=runtimesecret` — signing integration tests + security review
+3. A/B `GOEXPERIMENT=nogreenteagc` only to quantify Green Tea benefit; do not ship opt-out
+
+---
+
+## 8. Priority matrix (for gopdfsuit)
+
+```
+Impact ↑
+  │
+  │  Green Tea GC ●          Stack slice alloc ●
+  │  io.ReadAll ●            image/jpeg ●
+  │  go fix / B.Loop ●       goroutineleak exp ●
+  │  cgo (chromedp) ●        runtime/secret exp ●
+  │  new(expr) ○             errors.AsType ○
+  │  self-ref generics ○     simd/archsimd △
+  └──────────────────────────────────────────→ Effort
+        (already done)   (low)    (medium)   (research)
+```
+
+● = recommended focus · ○ = optional polish · △ = experimental / high uncertainty
+
+---
+
+## References
+
+- [Go 1.26 release notes](https://go.dev/doc/go1.26)
+- [Go 1.26 release blog post](https://go.dev/blog/go1.26)
+- Internal baselines: `guides/cursor/baselines/gin_pprof_runs/`
+- Optimization history: `guides/optimizations/20260614_remaining_optimizations_checklist.md`
+- Benchmark harness: `test/generate_template-pdf/run_gin_pprof_load.sh`

--- a/internal/benchmarktemplates/runner.go
+++ b/internal/benchmarktemplates/runner.go
@@ -61,10 +61,7 @@ func RunSingleDocumentBenchmark(name string) error {
 	}
 
 	iterations := envInt("BENCH_ITERATIONS", defaultWorkers)
-	workers := envInt("BENCH_WORKERS", defaultWorkers)
-	if workers > iterations {
-		workers = iterations
-	}
+	workers := min(envInt("BENCH_WORKERS", defaultWorkers), iterations)
 
 	fmt.Println(BenchmarkHeader(name))
 	fmt.Printf("Iterations: %d | Workers: %d\n", iterations, workers)
@@ -111,10 +108,7 @@ func RunSingleDocumentBenchmark(name string) error {
 	}
 
 	sort.Float64s(durations)
-	p95idx := int(math.Ceil(float64(len(durations))*0.95)) - 1
-	if p95idx < 0 {
-		p95idx = 0
-	}
+	p95idx := max(int(math.Ceil(float64(len(durations))*0.95))-1, 0)
 	completed := len(durations)
 	totalDur := 0.0
 	for _, d := range durations {

--- a/internal/benchmarktemplates/zerodha_retail.go
+++ b/internal/benchmarktemplates/zerodha_retail.go
@@ -10,12 +10,8 @@ import (
 	"github.com/chinmay-sawant/gopdfsuit/v6/pkg/gopdflib"
 )
 
-func boolPtr(value bool) *bool {
-	return &value
-}
-
 func floatPtr(value float64) *float64 {
-	return &value
+	return new(value)
 }
 
 func repoRoot() string {
@@ -74,7 +70,7 @@ func BuildZerodhaRetailTemplate() (gopdflib.PDFTemplate, error) {
 			PdfTitle:            "Contract Note - CN2024001",
 			PDFACompliant:       true,
 			ArlingtonCompatible: true,
-			EmbedFonts:          boolPtr(true),
+			EmbedFonts:          new(true),
 			Signature: &gopdflib.SignatureConfig{
 				Enabled:          true,
 				Visible:          true,

--- a/internal/benchmarktemplates/zerodha_retail.go
+++ b/internal/benchmarktemplates/zerodha_retail.go
@@ -10,14 +10,12 @@ import (
 	"github.com/chinmay-sawant/gopdfsuit/v6/pkg/gopdflib"
 )
 
-//go:fix inline
 func boolPtr(value bool) *bool {
-	return new(value)
+	return &value
 }
 
-//go:fix inline
 func floatPtr(value float64) *float64 {
-	return new(value)
+	return &value
 }
 
 func repoRoot() string {
@@ -76,7 +74,7 @@ func BuildZerodhaRetailTemplate() (gopdflib.PDFTemplate, error) {
 			PdfTitle:            "Contract Note - CN2024001",
 			PDFACompliant:       true,
 			ArlingtonCompatible: true,
-			EmbedFonts:          new(true),
+			EmbedFonts:          boolPtr(true),
 			Signature: &gopdflib.SignatureConfig{
 				Enabled:          true,
 				Visible:          true,
@@ -102,14 +100,14 @@ func BuildZerodhaRetailTemplate() (gopdflib.PDFTemplate, error) {
 							Text:      "CONTRACT NOTE",
 							BgColor:   "#154360",
 							TextColor: "#FFFFFF",
-							Height:    new(float64(45)),
+							Height:    floatPtr(45),
 						},
 						{
 							Props:     "Helvetica:11:000:right:0:0:0:0",
 							Text:      "CN2024001 | 2024-02-12",
 							BgColor:   "#154360",
 							TextColor: "#AED6F1",
-							Height:    new(float64(45)),
+							Height:    floatPtr(45),
 						},
 					}},
 				},

--- a/internal/benchmarktemplates/zerodha_retail.go
+++ b/internal/benchmarktemplates/zerodha_retail.go
@@ -10,12 +10,14 @@ import (
 	"github.com/chinmay-sawant/gopdfsuit/v6/pkg/gopdflib"
 )
 
+//go:fix inline
 func boolPtr(value bool) *bool {
-	return &value
+	return new(value)
 }
 
+//go:fix inline
 func floatPtr(value float64) *float64 {
-	return &value
+	return new(value)
 }
 
 func repoRoot() string {
@@ -74,7 +76,7 @@ func BuildZerodhaRetailTemplate() (gopdflib.PDFTemplate, error) {
 			PdfTitle:            "Contract Note - CN2024001",
 			PDFACompliant:       true,
 			ArlingtonCompatible: true,
-			EmbedFonts:          boolPtr(true),
+			EmbedFonts:          new(true),
 			Signature: &gopdflib.SignatureConfig{
 				Enabled:          true,
 				Visible:          true,
@@ -100,14 +102,14 @@ func BuildZerodhaRetailTemplate() (gopdflib.PDFTemplate, error) {
 							Text:      "CONTRACT NOTE",
 							BgColor:   "#154360",
 							TextColor: "#FFFFFF",
-							Height:    floatPtr(45),
+							Height:    new(float64(45)),
 						},
 						{
 							Props:     "Helvetica:11:000:right:0:0:0:0",
 							Text:      "CN2024001 | 2024-02-12",
 							BgColor:   "#154360",
 							TextColor: "#AED6F1",
-							Height:    floatPtr(45),
+							Height:    new(float64(45)),
 						},
 					}},
 				},

--- a/internal/handlers/json_decode.go
+++ b/internal/handlers/json_decode.go
@@ -34,7 +34,7 @@ var (
 // WarmJSONDecode pre-compiles the PDFTemplate JSON schema at process start.
 func WarmJSONDecode() {
 	jsonPretouchOnce.Do(func() {
-		_ = sonic.Pretouch(reflect.TypeOf(models.PDFTemplate{}))
+		_ = sonic.Pretouch(reflect.TypeFor[models.PDFTemplate]())
 		_ = decoder.NewStreamDecoder(io.NopCloser(nil))
 		var warm models.PDFTemplate
 		warm.PreallocForDecode(0, "hft")

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -148,8 +148,8 @@ func GetUserEmail(c *gin.Context) (string, bool) {
 }
 
 // GetUserInfo retrieves all user info from context
-func GetUserInfo(c *gin.Context) map[string]interface{} {
-	userInfo := make(map[string]interface{})
+func GetUserInfo(c *gin.Context) map[string]any {
+	userInfo := make(map[string]any)
 
 	if email, exists := c.Get("user_email"); exists {
 		userInfo["email"] = email

--- a/internal/pdf/benchmark_macro_test.go
+++ b/internal/pdf/benchmark_macro_test.go
@@ -21,7 +21,7 @@ func buildSyntheticTableTemplate(rows int) models.PDFTemplate {
 	}
 
 	tableRows := make([]models.Row, rows)
-	for i := 0; i < rows; i++ {
+	for i := range rows {
 		id := i + 1
 		tableRows[i] = models.Row{
 			Row: []models.Cell{

--- a/internal/pdf/bookmarks.go
+++ b/internal/pdf/bookmarks.go
@@ -66,7 +66,7 @@ func (pm *PageManager) generateBookmarkItems(items []models.Bookmark, parentID i
 	// First pass: Allocate IDs for all items at this level
 	startID := pm.NextObjectID
 	pm.NextObjectID += len(items)
-	for i := 0; i < len(items); i++ {
+	for i := range items {
 		itemIDs = append(itemIDs, startID+i)
 	}
 
@@ -116,10 +116,7 @@ func (pm *PageManager) generateBookmarkItems(items []models.Bookmark, parentID i
 		// Link to page (Dest)
 		// Destination array: [PageRef /Fit]
 		// Determine page object ID. Page numbers in models are 1-based.
-		pageIdx := item.Page - 1
-		if pageIdx < 0 {
-			pageIdx = 0
-		}
+		pageIdx := max(item.Page-1, 0)
 		if pageIdx >= len(pm.Pages) {
 			pageIdx = len(pm.Pages) - 1
 		}

--- a/internal/pdf/draw.go
+++ b/internal/pdf/draw.go
@@ -52,10 +52,7 @@ func drawWatermark(contentStream *bytes.Buffer, text string, pageDims PageDimens
 		return
 	}
 	// Proportional font size (fallback minimum)
-	fontSize := int(pageDims.Width / 8)
-	if fontSize < 40 {
-		fontSize = 40
-	}
+	fontSize := max(int(pageDims.Width/8), 40)
 	// Position roughly centered
 	x := pageDims.Width * 0.20
 	y := pageDims.Height * 0.30
@@ -222,7 +219,7 @@ func tableSupportsSharedRowLayout(table models.Table, templateRow int) bool {
 	for ri := templateRow + 1; ri < len(table.Rows); ri++ {
 		row := table.Rows[ri]
 		ncol := min(len(row.Row), len(template.Row), table.MaxColumns)
-		for ci := 0; ci < ncol; ci++ {
+		for ci := range ncol {
 			tc := template.Row[ci]
 			c := row.Row[ci]
 			if tc.Props != c.Props || c.Image != nil || c.FormField != nil || c.Checkbox != nil {

--- a/internal/pdf/encryption/encrypt.go
+++ b/internal/pdf/encryption/encrypt.go
@@ -80,7 +80,7 @@ func (enc *PDFEncryption) computeOwnerHash(userPassword, ownerPassword string) [
 	hash := md5.Sum(ownerPwd)
 
 	// Step 3: For R=4, do 50 iterations of MD5
-	for i := 0; i < 50; i++ {
+	for range 50 {
 		hash = md5.Sum(hash[:])
 	}
 
@@ -130,7 +130,7 @@ func (enc *PDFEncryption) computeEncryptionKey(userPassword string) []byte {
 	hash := hasher.Sum(nil)
 
 	// Step 3: For R=4, do 50 additional MD5 iterations on first 16 bytes
-	for i := 0; i < 50; i++ {
+	for range 50 {
 		h := md5.Sum(hash[:16])
 		hash = h[:]
 	}
@@ -170,13 +170,13 @@ func (enc *PDFEncryption) computeUserHash() []byte {
 func rc4Encrypt(key, data []byte) []byte {
 	// Initialize S-box
 	s := make([]byte, 256)
-	for i := 0; i < 256; i++ {
+	for i := range 256 {
 		s[i] = byte(i)
 	}
 
 	// Key-scheduling algorithm (KSA)
 	j := 0
-	for i := 0; i < 256; i++ {
+	for i := range 256 {
 		j = (j + int(s[i]) + int(key[i%len(key)])) % 256
 		s[i], s[j] = s[j], s[i]
 	}
@@ -184,7 +184,7 @@ func rc4Encrypt(key, data []byte) []byte {
 	// Pseudo-random generation algorithm (PRGA)
 	result := make([]byte, len(data))
 	i, j := 0, 0
-	for k := 0; k < len(data); k++ {
+	for k := range data {
 		i = (i + 1) % 256
 		j = (j + int(s[i])) % 256
 		s[i], s[j] = s[j], s[i]

--- a/internal/pdf/font/compression.go
+++ b/internal/pdf/font/compression.go
@@ -84,10 +84,7 @@ func CompressContentStream(raw []byte) (compressed *bytes.Buffer, useFlate bool)
 	}
 
 	if rawLen <= compressSkipSampleMin {
-		sampleLen := rawLen
-		if sampleLen > compressSampleBytes {
-			sampleLen = compressSampleBytes
-		}
+		sampleLen := min(rawLen, compressSampleBytes)
 		sampleBuf := GetCompressBuffer()
 		zw := GetZlibWriter(sampleBuf)
 		if _, err := zw.Write(raw[:sampleLen]); err != nil {

--- a/internal/pdf/font/metrics.go
+++ b/internal/pdf/font/metrics.go
@@ -964,10 +964,7 @@ func GenerateToUnicodeCMap(font *RegisteredFont, encryptor ObjectEncryptor) stri
 	// Write character mappings in chunks of 100 (PDF limit)
 	var ibuf [16]byte
 	for i := 0; i < len(mappings); i += 100 {
-		end := i + 100
-		if end > len(mappings) {
-			end = len(mappings)
-		}
+		end := min(i+100, len(mappings))
 		chunk := mappings[i:end]
 
 		cmap.Write(strconv.AppendInt(ibuf[:0], int64(len(chunk)), 10))

--- a/internal/pdf/font/registry.go
+++ b/internal/pdf/font/registry.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -165,9 +166,7 @@ func (r *CustomFontRegistry) GenerateSubsets() error {
 		if cached, ok := lookupCachedSubset(font.Font, usedGlyphs); ok {
 			font.SubsetData = cached.data
 			font.OldToNewGlyph = make(map[uint16]uint16, len(cached.oldToNew))
-			for k, v := range cached.oldToNew {
-				font.OldToNewGlyph[k] = v
-			}
+			maps.Copy(font.OldToNewGlyph, cached.oldToNew)
 			continue
 		}
 

--- a/internal/pdf/font/subset.go
+++ b/internal/pdf/font/subset.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
+	"slices"
 	"sort"
 )
 
@@ -32,9 +33,7 @@ func SubsetTTF(font *TTFFont, usedGlyphs []uint16) ([]byte, map[uint16]uint16, e
 	for glyph := range glyphSet {
 		sortedGlyphs = append(sortedGlyphs, glyph)
 	}
-	sort.Slice(sortedGlyphs, func(i, j int) bool {
-		return sortedGlyphs[i] < sortedGlyphs[j]
-	})
+	slices.Sort(sortedGlyphs)
 
 	// Create old-to-new glyph ID mapping
 	oldToNew := make(map[uint16]uint16)
@@ -191,7 +190,7 @@ func buildSubsetFont(font *TTFFont, glyphs []uint16, oldToNew map[uint16]uint16)
 
 		// Pad to 4-byte boundary
 		padding := (4 - len(data)%4) % 4
-		for i := 0; i < padding; i++ {
+		for range padding {
 			buf.WriteByte(0)
 		}
 	}
@@ -365,9 +364,7 @@ func subsetCmap(font *TTFFont, oldToNew map[uint16]uint16) []byte {
 	for char := range charToNewGlyph {
 		chars = append(chars, char)
 	}
-	sort.Slice(chars, func(i, j int) bool {
-		return chars[i] < chars[j]
-	})
+	slices.Sort(chars)
 
 	// Build segments
 	type segment struct {

--- a/internal/pdf/font/subset_cache.go
+++ b/internal/pdf/font/subset_cache.go
@@ -3,7 +3,8 @@ package font
 import (
 	"encoding/binary"
 	"hash/fnv"
-	"sort"
+	"maps"
+	"slices"
 	"sync"
 	"sync/atomic"
 )
@@ -30,7 +31,7 @@ func glyphSubsetFingerprint(font *TTFFont, usedGlyphs []uint16) uint64 {
 	h := fnv.New64a()
 	_, _ = h.Write([]byte(font.PostScriptName))
 	glyphs := append([]uint16(nil), usedGlyphs...)
-	sort.Slice(glyphs, func(i, j int) bool { return glyphs[i] < glyphs[j] })
+	slices.Sort(glyphs)
 	for _, g := range glyphs {
 		var b [2]byte
 		binary.BigEndian.PutUint16(b[:], g)
@@ -58,9 +59,7 @@ func storeCachedSubset(font *TTFFont, usedGlyphs []uint16, data []byte, oldToNew
 	}
 	key := glyphSubsetFingerprint(font, usedGlyphs)
 	oldCopy := make(map[uint16]uint16, len(oldToNew))
-	for k, v := range oldToNew {
-		oldCopy[k] = v
-	}
+	maps.Copy(oldCopy, oldToNew)
 	if subsetCacheCount.Add(1) > maxSubsetCacheEntries {
 		ClearSubsetCache()
 		subsetCacheCount.Store(1)

--- a/internal/pdf/font/subset_cache_test.go
+++ b/internal/pdf/font/subset_cache_test.go
@@ -34,7 +34,7 @@ func TestSubsetCacheBoundsEntries(t *testing.T) {
 	mapping := map[uint16]uint16{1: 1}
 
 	// Fill cache up to the limit with unique glyph sets.
-	for i := uint16(0); i < maxSubsetCacheEntries+10; i++ {
+	for i := range uint16(maxSubsetCacheEntries + 10) {
 		storeCachedSubset(base, []uint16{i + 100}, data, mapping)
 	}
 

--- a/internal/pdf/font/ttf.go
+++ b/internal/pdf/font/ttf.go
@@ -8,7 +8,7 @@ import (
 	"io"
 	"math"
 	"os"
-	"sort"
+	"slices"
 )
 
 // TTFFont represents a parsed TrueType/OpenType font with all necessary data for PDF embedding
@@ -410,7 +410,7 @@ func (f *TTFFont) parseCmapFormat4(data []byte, offset uint32) error {
 
 	// Read endCode array
 	endCodes := make([]uint16, segCount)
-	for i := uint16(0); i < segCount; i++ {
+	for i := range segCount {
 		if err := binary.Read(r, binary.BigEndian, &endCodes[i]); err != nil {
 			return fmt.Errorf("failed to read endCodes: %w", err)
 		}
@@ -422,7 +422,7 @@ func (f *TTFFont) parseCmapFormat4(data []byte, offset uint32) error {
 
 	// Read startCode array
 	startCodes := make([]uint16, segCount)
-	for i := uint16(0); i < segCount; i++ {
+	for i := range segCount {
 		if err := binary.Read(r, binary.BigEndian, &startCodes[i]); err != nil {
 			return fmt.Errorf("failed to read startCodes: %w", err)
 		}
@@ -430,7 +430,7 @@ func (f *TTFFont) parseCmapFormat4(data []byte, offset uint32) error {
 
 	// Read idDelta array
 	idDeltas := make([]int16, segCount)
-	for i := uint16(0); i < segCount; i++ {
+	for i := range segCount {
 		if err := binary.Read(r, binary.BigEndian, &idDeltas[i]); err != nil {
 			return fmt.Errorf("failed to read idDeltas: %w", err)
 		}
@@ -439,14 +439,14 @@ func (f *TTFFont) parseCmapFormat4(data []byte, offset uint32) error {
 	// Read idRangeOffset array
 	idRangeOffsetPos, _ := r.Seek(0, io.SeekCurrent)
 	idRangeOffsets := make([]uint16, segCount)
-	for i := uint16(0); i < segCount; i++ {
+	for i := range segCount {
 		if err := binary.Read(r, binary.BigEndian, &idRangeOffsets[i]); err != nil {
 			return fmt.Errorf("failed to read idRangeOffsets: %w", err)
 		}
 	}
 
 	// Build character to glyph mapping
-	for i := uint16(0); i < segCount; i++ {
+	for i := range segCount {
 		if startCodes[i] == 0xFFFF {
 			break
 		}
@@ -682,13 +682,7 @@ func (f *TTFFont) parseOS2(data []byte) error {
 	}
 
 	// Estimate StemV from weight class
-	f.StemV = int16(50 + (usWeightClass-400)/10)
-	if f.StemV < 50 {
-		f.StemV = 50
-	}
-	if f.StemV > 200 {
-		f.StemV = 200
-	}
+	f.StemV = min(max(int16(50+(usWeightClass-400)/10), 50), 200)
 
 	return nil
 }
@@ -768,9 +762,7 @@ func (f *TTFFont) GetUsedGlyphs(text string) []uint16 {
 		glyphs = append(glyphs, glyph)
 	}
 
-	sort.Slice(glyphs, func(i, j int) bool {
-		return glyphs[i] < glyphs[j]
-	})
+	slices.Sort(glyphs)
 
 	return glyphs
 }

--- a/internal/pdf/form/xfdf.go
+++ b/internal/pdf/form/xfdf.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"regexp"
 	"sort"
 	"strconv"
@@ -267,10 +268,7 @@ func tryFlateDecompress(b []byte) ([]byte, error) {
 
 // extractTokenGroups looks for /V or /AS tokens near a position
 func extractTokenGroups(content []byte, pos int) (string, string) {
-	limit := pos + 800
-	if limit > len(content) {
-		limit = len(content)
-	}
+	limit := min(pos+800, len(content))
 	window := content[pos:limit]
 
 	if m := reValue.FindSubmatch(window); m != nil {
@@ -832,12 +830,8 @@ func FillPDFWithXFDFAdvanced(pdfBytes, xfdfBytes []byte) ([]byte, error) {
 	}
 
 	mergedFields := make(map[string]string)
-	for name, value := range detectedFields {
-		mergedFields[name] = value
-	}
-	for name, value := range xfdfFields {
-		mergedFields[name] = value
-	}
+	maps.Copy(mergedFields, detectedFields)
+	maps.Copy(mergedFields, xfdfFields)
 
 	// Build a synthetic XFDF from merged fields so FillPDFWithXFDF can reuse logic
 	genXFDF := buildXFDF(mergedFields)
@@ -1280,11 +1274,11 @@ func repairStartxref(out []byte) []byte {
 
 	after := out[sxIdx+len("startxref"):]
 	after = bytes.TrimLeft(after, "\r\n")
-	lineEnd := bytes.IndexByte(after, '\n')
-	if lineEnd < 0 {
+	_, after0, ok := bytes.Cut(after, []byte{'\n'})
+	if !ok {
 		return out
 	}
-	rest := after[lineEnd+1:]
+	rest := after0
 
 	var rebuilt bytes.Buffer
 	rebuilt.Grow(len(out) + 16)

--- a/internal/pdf/generator.go
+++ b/internal/pdf/generator.go
@@ -821,7 +821,6 @@ func GenerateTemplatePDFBorrowed(template models.PDFTemplate) (doc *BorrowedPDF,
 	useFlate := make([]bool, nStreams)
 	var compGroup errgroup.Group
 	for si := range pageManager.ContentStreams {
-		si := si
 		compGroup.Go(func() error {
 			pageCompressSlots <- struct{}{}
 			defer func() { <-pageCompressSlots }()
@@ -1238,7 +1237,7 @@ func GenerateTemplatePDFBorrowed(template models.PDFTemplate) (doc *BorrowedPDF,
 		// Iterate through all pages that have marked content
 		// We iterate by page index to keep Nums sorted
 		maxPageIndex := len(pageManager.Pages)
-		for i := 0; i < maxPageIndex; i++ {
+		for i := range maxPageIndex {
 			if i < len(pageManager.Structure.ParentTree) {
 				elems := pageManager.Structure.ParentTree[i]
 				if len(elems) > 0 {
@@ -1357,7 +1356,7 @@ func GenerateTemplatePDFBorrowed(template models.PDFTemplate) (doc *BorrowedPDF,
 					// Shift existing digits right
 					b = b[:10]
 					copy(b[padding:], b[:10-padding])
-					for k := 0; k < padding; k++ {
+					for k := range padding {
 						b[k] = '0'
 					}
 				}
@@ -1842,7 +1841,7 @@ func generateAllContentWithImages(template models.PDFTemplate, pageManager *Page
 
 	// Draw footer and page numbers on every page (footer first to avoid overlap)
 	totalPages := len(pageManager.Pages)
-	for i := 0; i < totalPages; i++ {
+	for i := range totalPages {
 		// Set CurrentPageIndex so that any annotations added (e.g. by drawFooter) go to the correct page
 		pageManager.CurrentPageIndex = i
 

--- a/internal/pdf/image.go
+++ b/internal/pdf/image.go
@@ -323,9 +323,9 @@ func convertToRGB(img image.Image, rgbData []byte) error {
 	// Fast paths for common types (avoids repeated type assertions)
 	switch v := img.(type) {
 	case *image.NRGBA:
-		for y := 0; y < height; y++ {
+		for y := range height {
 			rowStart := (y + bounds.Min.Y - v.Rect.Min.Y) * v.Stride
-			for x := 0; x < width; x++ {
+			for x := range width {
 				pixOffset := rowStart + (x+bounds.Min.X-v.Rect.Min.X)*4
 				rgbData[idx] = v.Pix[pixOffset]
 				rgbData[idx+1] = v.Pix[pixOffset+1]
@@ -335,9 +335,9 @@ func convertToRGB(img image.Image, rgbData []byte) error {
 		}
 		return nil
 	case *image.RGBA:
-		for y := 0; y < height; y++ {
+		for y := range height {
 			rowStart := (y + bounds.Min.Y - v.Rect.Min.Y) * v.Stride
-			for x := 0; x < width; x++ {
+			for x := range width {
 				pixOffset := rowStart + (x+bounds.Min.X-v.Rect.Min.X)*4
 				rgbData[idx] = v.Pix[pixOffset]
 				rgbData[idx+1] = v.Pix[pixOffset+1]
@@ -385,9 +385,9 @@ func convertToRGBWithAlpha(img image.Image, rgbData []byte) error {
 		stride := v.Stride
 		minX := bounds.Min.X - v.Rect.Min.X
 		minY := bounds.Min.Y - v.Rect.Min.Y
-		for y := 0; y < height; y++ {
+		for y := range height {
 			rowStart := (y + minY) * stride
-			for x := 0; x < width; x++ {
+			for x := range width {
 				pixOffset := rowStart + (x+minX)*4
 				r := uint32(pix[pixOffset])
 				g := uint32(pix[pixOffset+1])

--- a/internal/pdf/image_cache_test.go
+++ b/internal/pdf/image_cache_test.go
@@ -33,7 +33,7 @@ func TestImageCacheBoundsEntries(t *testing.T) {
 	ResetImageCache()
 
 	// Generate many tiny unique PNGs to overflow the cache.
-	for i := 0; i < maxImageCacheEntries+10; i++ {
+	for i := range maxImageCacheEntries + 10 {
 		unique := base64.StdEncoding.EncodeToString([]byte{byte(i), byte(i >> 8), 0x89, 0x50, 0x4e, 0x47})
 		// Not all will decode, but each call exercises the store path.
 		_, _ = DecodeImageData(unique)

--- a/internal/pdf/links.go
+++ b/internal/pdf/links.go
@@ -85,8 +85,8 @@ func ParseLink(link string) (isExternal bool, uri string, dest string) {
 	}
 
 	// Check for internal bookmark link (starts with #)
-	if strings.HasPrefix(link, "#") {
-		return false, "", strings.TrimPrefix(link, "#")
+	if after, ok := strings.CutPrefix(link, "#"); ok {
+		return false, "", after
 	}
 
 	// Check for common URL schemes

--- a/internal/pdf/merge/split.go
+++ b/internal/pdf/merge/split.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 )
@@ -131,10 +132,7 @@ func SplitPDF(file []byte, spec SplitSpec) ([][]byte, error) {
 	var groups [][]int
 	if spec.MaxPerFile > 0 {
 		for i := 0; i < len(orderedPages); i += spec.MaxPerFile {
-			end := i + spec.MaxPerFile
-			if end > len(orderedPages) {
-				end = len(orderedPages)
-			}
+			end := min(i+spec.MaxPerFile, len(orderedPages))
 			groups = append(groups, orderedPages[i:end])
 		}
 	} else {
@@ -281,10 +279,8 @@ func isExcludedForSplit(fc *FileContext, objNum int) bool {
 	if fc.OriginalPagesTree > 0 && objNum == fc.OriginalPagesTree {
 		return true
 	}
-	for _, n := range fc.ObjectStreamNums {
-		if objNum == n {
-			return true
-		}
+	if slices.Contains(fc.ObjectStreamNums, objNum) {
+		return true
 	}
 	// exclude Pages tree nodes (intermediate)
 	if body, ok := fc.Objects[objNum]; ok {

--- a/internal/pdf/metadata.go
+++ b/internal/pdf/metadata.go
@@ -202,8 +202,8 @@ func (h *PDFAHandler) GenerateXMPMetadata(documentID string) (int, string) {
 		xmp.WriteString("\n")
 		xmp.WriteString(`        <rdf:Bag>`)
 		xmp.WriteString("\n")
-		keywords := strings.Split(h.config.Keywords, ",")
-		for _, kw := range keywords {
+		keywords := strings.SplitSeq(h.config.Keywords, ",")
+		for kw := range keywords {
 			if len(kw) > 0 {
 				start, end := 0, len(kw)
 				for start < end && kw[start] == ' ' {

--- a/internal/pdf/pagemanager.go
+++ b/internal/pdf/pagemanager.go
@@ -203,10 +203,7 @@ func (pm *PageManager) PrepareLargeTableStripe(rowHeight float64, cols int) {
 	if rowHeight <= 0 || cols <= 0 {
 		return
 	}
-	rowsPerPage := int((pm.CurrentYPos - pm.Margins.Bottom) / rowHeight)
-	if rowsPerPage < 1 {
-		rowsPerPage = 1
-	}
+	rowsPerPage := max(int((pm.CurrentYPos-pm.Margins.Bottom)/rowHeight), 1)
 	est := rowsPerPage * cols * 512
 	if est <= pm.InitialStreamCap {
 		return

--- a/internal/pdf/pdfa.go
+++ b/internal/pdf/pdfa.go
@@ -145,7 +145,7 @@ func buildSRGBICCProfile() []byte {
 	// Use inverse sRGB gamma curve (linearization) to compensate for matrix conversion
 	// This curve converts sRGB-encoded values to linear, which is what Adobe expects
 	gammaTable := make([]uint16, 1024)
-	for i := 0; i < 1024; i++ {
+	for i := range 1024 {
 		x := float64(i) / 1023.0
 		var y float64
 		// sRGB to linear (inverse gamma)
@@ -382,7 +382,7 @@ func GenerateGrayICCProfileObject(objectID int, encryptor ObjectEncryptor) []byt
 func buildGrayICCProfile() []byte {
 	// Pre-calculate gamma table (same sRGB gamma for gray)
 	gammaTable := make([]uint16, 1024)
-	for i := 0; i < 1024; i++ {
+	for i := range 1024 {
 		x := float64(i) / 1023.0
 		var y float64
 		if x <= 0.0031308 {

--- a/internal/pdf/props_cache_test.go
+++ b/internal/pdf/props_cache_test.go
@@ -20,7 +20,7 @@ func TestPropsCacheBoundsEntries(t *testing.T) {
 	ClearPropsCache()
 
 	// Fill cache beyond its limit with unique strings.
-	for i := 0; i < maxPropsCacheEntries+10; i++ {
+	for i := range maxPropsCacheEntries + 10 {
 		parseProps("Arial:10:000:left:0:0:0:0:" + string(rune(i)))
 	}
 

--- a/internal/pdf/redact/encryption_inhouse.go
+++ b/internal/pdf/redact/encryption_inhouse.go
@@ -237,7 +237,7 @@ func deriveFileKey(password string, d standardEncryptDict, id0 []byte) []byte {
 	}
 	sum := h.Sum(nil)
 	if d.R >= 3 {
-		for i := 0; i < 50; i++ {
+		for range 50 {
 			x := md5.Sum(sum[:keyLen])
 			sum = x[:]
 		}
@@ -281,7 +281,7 @@ func deriveUserPasswordFromOwner(ownerPassword string, d standardEncryptDict) st
 	h := md5.Sum(padPassword(ownerPassword))
 	k := h[:]
 	if d.R >= 3 {
-		for i := 0; i < 50; i++ {
+		for range 50 {
 			x := md5.Sum(k[:keyLen])
 			k = x[:]
 		}
@@ -318,7 +318,7 @@ func decryptObjectStreams(objBody []byte, fileKey []byte, objNum, genNum int) ([
 	out = append(out, dec...)
 	out = append(out, objBody[loc[3]:]...)
 	lenRe := regexp.MustCompile(`/Length\s+\d+`)
-	out = lenRe.ReplaceAll(out, []byte(fmt.Sprintf(`/Length %d`, len(dec))))
+	out = lenRe.ReplaceAll(out, fmt.Appendf(nil, `/Length %d`, len(dec)))
 	return out, true
 }
 
@@ -328,10 +328,7 @@ func deriveObjectKey(fileKey []byte, objNum, genNum int) []byte {
 	b = append(b, byte(objNum), byte(objNum>>8), byte(objNum>>16))
 	b = append(b, byte(genNum), byte(genNum>>8))
 	h := md5.Sum(b)
-	kLen := len(fileKey) + 5
-	if kLen > 16 {
-		kLen = 16
-	}
+	kLen := min(len(fileKey)+5, 16)
 	return h[:kLen]
 }
 

--- a/internal/pdf/redact/pdf_utils.go
+++ b/internal/pdf/redact/pdf_utils.go
@@ -286,7 +286,7 @@ func findPageResources(pageBody []byte, objMap map[int][]byte) []byte {
 	}
 	parentRe := regexp.MustCompile(`/Parent\s+(\d+)\s+(\d+)\s+R`)
 	cur := pageBody
-	for depth := 0; depth < 16; depth++ {
+	for range 16 {
 		m := parentRe.FindSubmatch(cur)
 		if m == nil {
 			break
@@ -866,7 +866,7 @@ func xrefEntryBytes(offset, gen int) []byte {
 	var buf [20]byte
 	pos := 9
 	off := offset
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		buf[pos] = byte('0' + off%10)
 		off /= 10
 		pos--
@@ -874,7 +874,7 @@ func xrefEntryBytes(offset, gen int) []byte {
 	buf[10] = ' '
 	pos = 15
 	g := gen
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		buf[pos] = byte('0' + g%10)
 		g /= 10
 		pos--

--- a/internal/pdf/redact/search.go
+++ b/internal/pdf/redact/search.go
@@ -193,7 +193,7 @@ func (r *Redactor) buildSubstringRects(pageNum int, pos models.TextPosition, low
 				offsetEst += estimateStringWidth(string(origSrc[j]), pos.Height)
 			}
 		}
-		for j := 0; j < len(needle); j++ {
+		for j := range needle {
 			if i+j < len(origSrc) {
 				matchEst += estimateStringWidth(string(origSrc[i+j]), pos.Height)
 			}
@@ -366,18 +366,12 @@ func (r *Redactor) findAllCombinedMatchRects(pageNum int, positions []models.Tex
 				if tokenEst > 0 && s.pos.Width > 0 && len(tokenText) > 0 {
 					scale := s.pos.Width / tokenEst
 
-					overlapStart := matchStart - s.start
-					if overlapStart < 0 {
-						overlapStart = 0
-					}
+					overlapStart := max(matchStart-s.start, 0)
 
-					overlapEnd := matchEnd - s.start
-					if overlapEnd > s.end-s.start {
-						overlapEnd = s.end - s.start
-					}
+					overlapEnd := min(matchEnd-s.start, s.end-s.start)
 
 					var offsetEst, matchEst float64
-					for j := 0; j < overlapStart; j++ {
+					for j := range overlapStart {
 						if j < len(tokenText) {
 							offsetEst += estimateStringWidth(string(tokenText[j]), s.pos.Height)
 						}

--- a/internal/pdf/signature/signature.go
+++ b/internal/pdf/signature/signature.go
@@ -367,10 +367,7 @@ func (s *PDFSigner) CreateSignatureField(pageManager SignaturePageContext, pageD
 	pageManager.SetExtraObject(sigAnnotID, annotDict.String())
 
 	// Add annotation to the appropriate page
-	pageIndex := targetPage - 1
-	if pageIndex < 0 {
-		pageIndex = 0
-	}
+	pageIndex := max(targetPage-1, 0)
 	pageManager.AppendPageAnnot(pageIndex, sigAnnotID)
 
 	ids.SigFieldID = sigAnnotID // In this implementation, field = annotation
@@ -694,7 +691,7 @@ type attribute struct {
 	Value asn1.RawValue `asn1:"set"`
 }
 
-func mustMarshal(v interface{}) []byte {
+func mustMarshal(v any) []byte {
 	b, err := asn1.Marshal(v)
 	if err != nil {
 		panic(err)

--- a/internal/pdf/structure.go
+++ b/internal/pdf/structure.go
@@ -447,7 +447,7 @@ func (sm *StructureManager) AttachRowMCIDs(pageIndex, startMCID, count int) {
 	_ = startMCID
 	parent := sm.CurrentParent
 	sm.appendParentTreeRefs(pageIndex, parent, count)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		parent.Kids = append(parent.Kids, StructKid{MCID: startMCID + i})
 	}
 }
@@ -481,7 +481,7 @@ func (sm *StructureManager) FillDeferredParentTreePage(pageIndex int, parent *St
 		return
 	}
 	sm.appendParentTreeRefs(pageIndex, parent, count)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		parent.Kids = append(parent.Kids, StructKid{MCID: startMCID + i})
 	}
 }

--- a/internal/pdf/structure_test.go
+++ b/internal/pdf/structure_test.go
@@ -49,7 +49,7 @@ func TestBeginMarkedContentBufWithMCID_createsTDUnderTR(t *testing.T) {
 
 	var buf bytes.Buffer
 	base := sm.ReserveMCIDs(0, 3)
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		sm.BeginMarkedContentBufWithMCID(&buf, 0, StructTD, nil, base+i)
 		sm.EndMarkedContentBuf(&buf)
 	}

--- a/internal/pdf/svg/svg.go
+++ b/internal/pdf/svg/svg.go
@@ -228,8 +228,8 @@ func processElement(b *bytes.Buffer, se xml.StartElement) {
 
 	// Parse style attribute if present
 	if style, ok := attrs["style"]; ok {
-		styleParts := strings.Split(style, ";")
-		for _, part := range styleParts {
+		styleParts := strings.SplitSeq(style, ";")
+		for part := range styleParts {
 			part = strings.TrimSpace(part)
 			if part == "" {
 				continue
@@ -395,8 +395,8 @@ func parseColor(c string) (float64, float64, float64, bool) {
 // parseColorComponent parses a single RGB component (0-255 or percentage)
 func parseColorComponent(s string) float64 {
 	s = strings.TrimSpace(s)
-	if strings.HasSuffix(s, "%") {
-		val, _ := strconv.ParseFloat(strings.TrimSuffix(s, "%"), 64)
+	if before, ok := strings.CutSuffix(s, "%"); ok {
+		val, _ := strconv.ParseFloat(before, 64)
 		return val / 100.0
 	}
 	val, _ := strconv.ParseFloat(s, 64)

--- a/internal/pdf/xref/xref.go
+++ b/internal/pdf/xref/xref.go
@@ -83,7 +83,7 @@ func WriteCompactXRef(out *bytes.Buffer, offsets map[int]int, scratch []byte, st
 				if padding > 0 {
 					b = b[:10]
 					copy(b[padding:], b[:10-padding])
-					for k := 0; k < padding; k++ {
+					for k := range padding {
 						b[k] = '0'
 					}
 				}

--- a/sampledata/benchmarks/gopdflib/benchconfig.go
+++ b/sampledata/benchmarks/gopdflib/benchconfig.go
@@ -20,18 +20,6 @@ func benchDataWorkers() int {
 	return envInt("BENCH_WORKERS", defaultDataWorkers)
 }
 
-func benchZerodhaIterations() int {
-	return envInt("BENCH_ITERATIONS", defaultZerodhaIters)
-}
-
-func benchZerodhaWorkers() int {
-	return envInt("BENCH_WORKERS", numWorkersFromEnv())
-}
-
-func numWorkersFromEnv() int {
-	return envInt("BENCH_WORKERS", defaultDataWorkers)
-}
-
 func benchQuiet() bool {
 	return os.Getenv("BENCH_QUIET") == "1"
 }

--- a/typstsyntax/renderer.go
+++ b/typstsyntax/renderer.go
@@ -473,9 +473,9 @@ func (le *LayoutEngine) layoutMatrixGrid(node *Node, fontSize float64) (grid *Ma
 	rowHeights := make([]float64, rowCount)
 
 	idx := 0
-	for r := 0; r < rowCount; r++ {
+	for r := range rowCount {
 		gridCells[r] = make([]*MathLayout, cols)
-		for c := 0; c < cols; c++ {
+		for c := range cols {
 			if idx >= len(node.Args) {
 				break
 			}
@@ -497,7 +497,7 @@ func (le *LayoutEngine) layoutMatrixGrid(node *Node, fontSize float64) (grid *Ma
 
 	// Calculate total grid height
 	totalGridHeight := 0.0
-	for r := 0; r < rowCount; r++ {
+	for r := range rowCount {
 		totalGridHeight += rowHeights[r]
 		if r > 0 {
 			totalGridHeight += rowGap
@@ -513,7 +513,7 @@ func (le *LayoutEngine) layoutMatrixGrid(node *Node, fontSize float64) (grid *Ma
 	bBottom := yShift - totalGridHeight + rowHeights[0]*0.3
 
 	innerW := 0.0
-	for c := 0; c < cols; c++ {
+	for c := range cols {
 		innerW += colWidths[c]
 		if c > 0 {
 			innerW += colGap
@@ -526,17 +526,17 @@ func (le *LayoutEngine) layoutMatrixGrid(node *Node, fontSize float64) (grid *Ma
 	padding := fontSize * 0.12
 	colX := make([]float64, cols)
 	x := padding
-	for c := 0; c < cols; c++ {
+	for c := range cols {
 		colX[c] = x
 		x += colWidths[c] + colGap
 	}
 
 	y := yShift
-	for r := 0; r < rowCount; r++ {
+	for r := range rowCount {
 		if r > 0 {
 			y -= rowHeights[r-1] + rowGap
 		}
-		for c := 0; c < cols; c++ {
+		for c := range cols {
 			cellLay := gridCells[r][c]
 			if cellLay == nil {
 				continue


### PR DESCRIPTION
Updated the go syntax to the latest 1.26.4 version 